### PR TITLE
Button consistency

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -8,5 +8,6 @@ main.index
           .guests =  episode.data.guests
           .summary = episode.summary
         .actions
-          = link_to "Show Notes", episode
           = partial(:player, locals: {media_url: episode.data.media_url})
+          = link_to "Download", episode.data.media_url
+          = link_to "Show Notes", episode

--- a/source/layouts/episodes_layout.slim
+++ b/source/layouts/episodes_layout.slim
@@ -8,5 +8,5 @@
           .summary
             = yield
           .actions
-            = link_to "Download", current_article.data.media_url
             = partial(:player, locals: {media_url: current_article.data.media_url})
+            = link_to "Download", current_article.data.media_url

--- a/source/stylesheets/all.css.scss
+++ b/source/stylesheets/all.css.scss
@@ -20,6 +20,7 @@ $mobile: new-breakpoint(max-width 500px 4);
 
 .player {
   background-color: $yellow;
+  margin-right: 1em;
 }
 header {
   margin-top: 160px;

--- a/source/stylesheets/bar-ui.css.scss
+++ b/source/stylesheets/bar-ui.css.scss
@@ -15,8 +15,6 @@
  font-smoothing: antialiased;
  text-rendering: optimizeLegibility;
  max-width: 5em;
- /* take out overflow if you want an absolutely-positioned playlist dropdown. */
- overflow: hidden;
  /* just for fun (animate normal / full-width) */
  transition: max-width 0.2s ease-in-out;
 }


### PR DESCRIPTION
A couple of times I've visited the site (after each episode has been announced), gone to look for the Download buttton, clicked Show Notes, hit back, gotten confused, etc. I think the current setup of swapping the _Show Notes_ with _Downloads_ may be easy to miss.

I've had a go at keeping the positions consistent in the single and index markup, and also tried bring the Play button back into alignment:

![screen shot 2015-04-09 at 10 59 13 pm](https://cloud.githubusercontent.com/assets/133028/7067184/a06947fa-df0c-11e4-9dc4-e20e87e32bce.png)
![screen shot 2015-04-09 at 10 59 37 pm](https://cloud.githubusercontent.com/assets/133028/7067188/a841914e-df0c-11e4-9f15-1c96ca91c74e.png)

(Thanks for doing the podcast. :smiley: )
